### PR TITLE
ci: decouple auto-merge from claude-review

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -72,8 +72,7 @@ jobs:
 
   auto-merge:
     runs-on: ubuntu-latest
-    needs: [claude-review]
-    if: needs.claude-review.result == 'success' && github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary
- Remove `needs: [claude-review]` dependency from auto-merge job
- Auto-merge now runs independently so claude-review failures don't block dependabot merges
- Matches fix already applied in the-craftist-website (#106)

## Test plan
- [ ] Verify auto-merge job triggers on next dependabot PR without waiting for claude-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)