### PR TITLE
fix: update dompurify to 3.4.0 (GHSA-39q2-94rc-95cp)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11801,9 +11801,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #81 — DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation
- Transitive dep: `tinacms` → `mermaid@9.3.0` / `posthog-js@1.352.0` → `dompurify`
- `npm update dompurify` bumped 3.3.3 → 3.4.0 under the existing `^3.3.1` override (no package.json change needed)

## Test plan
- [x] `npm ls dompurify` now shows 3.4.0 on both branches of the dep tree
- [ ] CI green (lint, build, unit tests, smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)