### PR TITLE
chore(deps): ignore astro/@astrojs major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
+    ignore:
+      # astro 6 is blocked by @vite-pwa/astro peer range (caps at astro 5).
+      # Revisit when @vite-pwa/astro publishes astro 6 support.
+      - dependency-name: "astro"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@astrojs/*"
+        update-types: ["version-update:semver-major"]
     groups:
       astro:
         patterns:


### PR DESCRIPTION
## Summary
- Ignores major-version bumps for \`astro\` and \`@astrojs/*\` in Dependabot
- Prevents failing PRs until \`@vite-pwa/astro\` publishes astro 6 support

## Context
PR #159 (astro 6 group) failed because \`@vite-pwa/astro@1.2.0\` peer range is \`astro@"^1.6.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"\`. Until vite-pwa/astro ships astro 6 support, any astro-6 PR will break \`npm ci\`.

Minor/patch bumps are still allowed, so astro 5.x updates continue as normal.

## Test plan
- [ ] Dependabot run on Monday produces no astro-major PR
- [ ] Remove ignore entries once \`@vite-pwa/astro\` supports astro 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)