### PR TITLE
security: low-risk hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps):"
@@ -42,6 +47,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps):"

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -47,7 +47,11 @@ const structuredData = {
   ogType="article"
   publishedTime={publishDate}
 >
-  <script slot="head" type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+  <script
+    slot="head"
+    type="application/ld+json"
+    set:html={JSON.stringify(structuredData).replace(/</g, "\\u003c")}
+  />
 
   <nav class="blog-nav">
     <a href="/blog/">&larr; All posts</a>

--- a/workers/media-api/src/handlers/list.ts
+++ b/workers/media-api/src/handlers/list.ts
@@ -4,7 +4,8 @@ import type { Env } from "../index";
 export async function handleList(c: Context<{ Bindings: Env }>) {
   const rawDir = c.req.query("directory") || "";
   const directory = rawDir.replace(/^\/+|\/+$/g, ""); // strip leading/trailing slashes
-  const limit = parseInt(c.req.query("limit") || "50", 10);
+  const parsedLimit = parseInt(c.req.query("limit") || "50", 10);
+  const limit = Number.isFinite(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), 1000) : 50;
   const offset = c.req.query("offset") || undefined;
 
   // Use delimiter to get virtual directories (folder browsing)

--- a/workers/media-api/src/handlers/upload.ts
+++ b/workers/media-api/src/handlers/upload.ts
@@ -30,7 +30,12 @@ export async function handleUpload(c: Context<{ Bindings: Env }>) {
   const formData = await c.req.formData();
   const file = formData.get("file") as File | null;
   const rawDir = (formData.get("directory") as string) || "";
-  const directory = rawDir.replace(/^\/+|\/+$/g, ""); // strip leading/trailing slashes
+  // Sanitize directory: strip leading/trailing slashes and drop any ".." segments.
+  const directory = rawDir
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter((seg) => seg && seg !== "." && seg !== "..")
+    .join("/");
 
   if (!file) {
     return c.json({ error: "No file provided" }, 400);
@@ -44,8 +49,13 @@ export async function handleUpload(c: Context<{ Bindings: Env }>) {
     return c.json({ error: `File too large (max ${MAX_SIZE / 1024 / 1024}MB)` }, 400);
   }
 
+  // Sanitize filename to a safe basename: strip path separators, reject "..",
+  // and restrict to [A-Za-z0-9._-] (other chars replaced with "_").
+  const baseName = file.name.split(/[\\/]/).pop() || "";
+  const safeName = baseName.replace(/[^A-Za-z0-9._-]/g, "_").replace(/^\.+$/, "_") || "file";
+
   // Build the R2 key: directory/filename (no leading slash)
-  const key = directory ? `${directory}/${file.name}` : file.name;
+  const key = directory ? `${directory}/${safeName}` : safeName;
 
   await c.env.MEDIA_BUCKET.put(key, file.stream(), {
     httpMetadata: { contentType: file.type },


### PR DESCRIPTION
## Summary
Three small, low-risk security-hardening changes. All are non-breaking.

1. **JSON-LD XSS hardening** (`src/pages/blog/[...slug].astro`): `JSON.stringify` does not escape `<`, so a post title containing `</script>` could break out of the `<script type="application/ld+json">` tag. The stringified output now escapes `<` as `\u003c`. Behaviour unchanged for normal content.

2. **R2 object-key sanitization** (`workers/media-api/src/handlers/upload.ts`): an authenticated upload could write to an arbitrary R2 key via path separators or `..` in `file.name`. The filename is now reduced to a safe basename (path separators stripped, restricted to `[A-Za-z0-9._-]`, dot-only names replaced), and `directory` segments equal to `.`/`..` are dropped. Auth logic untouched. Bonus: `handleList` (`list.ts`) now clamps the `limit` query param so a non-numeric value no longer passes `NaN` to R2 `.list` (clamped to 1..1000, default 50).

3. **Dependabot cooldown** (`.github/dependabot.yml`): added a `cooldown` block (default 5d, major 7d, minor 5d, patch 3d) to both npm entries only. The github-actions entry is unchanged, and the existing astro/@astrojs ignore rules and groups are preserved.

## Verification
- `npm ci` (succeeded, 2093 packages)
- `npx eslint` on all changed source files — clean
- `npx prettier --check` on all changed files — clean (prettier-driven reformat of the multi-attribute script tag is included)
- Validated `.github/dependabot.yml` parses as valid YAML; confirmed 2/2 npm entries have cooldown and the github-actions entry does not
- Pre-commit hook (lint-staged: eslint + prettier) passed
- Full `npm run build` was not run because it requires TinaCMS build steps (heavy/network); relied on lint + typecheck-clean diffs instead