### PR TITLE
Fix 6 confirmed bugs from code audit

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -3,7 +3,10 @@ import { getCollection, render } from "astro:content";
 import BlogLayout from "../../layouts/BlogLayout.astro";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
+  // Exclude drafts from production builds so unpublished posts are neither
+  // reachable by URL nor indexed (matches the filter on the listing pages).
+  // Drafts remain viewable during `astro dev` for previewing.
+  const posts = (await getCollection("blog")).filter((p) => import.meta.env.DEV || !p.data.draft);
   return posts.map((post) => ({
     params: { slug: post.slug },
     props: { post },

--- a/src/scripts/parallax.ts
+++ b/src/scripts/parallax.ts
@@ -57,20 +57,43 @@ export class ParallaxController {
     if (this.isMobile && this.hasOrientation) {
       // Check if iOS needs permission prompt (requires user gesture)
       if (ParallaxController.needsPermissionPrompt()) {
-        // iOS 13+ - defer to user gesture, use auto-drift for now
-        this.useAutoDrift = true;
+        // iOS 13+ requires an explicit user gesture to grant orientation
+        // permission. If the user already granted it (persisted across the
+        // page reload triggered by the prompt), the permission survives for
+        // the session, so we can re-attach the listener directly without
+        // re-prompting (requestPermission would reject without a gesture).
+        // tryDirectOrientation handles the auto-drift fallback if no events
+        // actually arrive.
+        if (this.hasStoredPermission()) {
+          await this.tryDirectOrientation();
+        } else {
+          // Defer to user gesture; use auto-drift until permission is granted.
+          this.useAutoDrift = true;
+        }
       } else {
-        // Android or older iOS - try direct orientation
+        // Android or older iOS - try direct orientation. tryDirectOrientation
+        // enables auto-drift itself via its timeout if no events arrive, so we
+        // must NOT unconditionally enable auto-drift here.
         await this.tryDirectOrientation();
       }
     } else if (!this.isMobile) {
       // Use mouse tracking on desktop
       window.addEventListener("mousemove", this.handleMouseMove);
-    }
-
-    // If on mobile and orientation not working, ensure auto-drift is on
-    if (this.isMobile && !this.orientationPermissionGranted) {
+    } else {
+      // Mobile device without DeviceOrientationEvent support.
       this.useAutoDrift = true;
+    }
+  }
+
+  /**
+   * Whether the user previously granted orientation permission (persisted by
+   * MotionPermissionPrompt before reloading the page).
+   */
+  private hasStoredPermission(): boolean {
+    try {
+      return localStorage.getItem("motion-permission-granted") === "true";
+    } catch {
+      return false;
     }
   }
 
@@ -132,6 +155,9 @@ export class ParallaxController {
   private onDeviceOrientation(e: DeviceOrientationEvent): void {
     if (e.gamma !== null && e.beta !== null) {
       this.orientationPermissionGranted = true;
+      // Real gyro input has arrived: stop overwriting targetX/targetY with the
+      // auto-drift pattern so the device tilt actually drives the parallax.
+      this.useAutoDrift = false;
 
       // gamma is left-right tilt (-90 to 90)
       // beta is front-back tilt (-180 to 180)

--- a/workers/media-api/src/handlers/upload.ts
+++ b/workers/media-api/src/handlers/upload.ts
@@ -7,7 +7,9 @@ const ALLOWED_TYPES = new Set([
   "image/png",
   "image/gif",
   "image/webp",
-  "image/svg+xml",
+  // NOTE: image/svg+xml is intentionally NOT allowed. SVGs can embed <script>
+  // and event-handler attributes; because media is served inline from the
+  // public bucket (PUBLIC_MEDIA_URL) it would execute as stored XSS.
   "image/avif",
   // Audio
   "audio/mpeg",
@@ -26,8 +28,69 @@ const ALLOWED_TYPES = new Set([
 
 const MAX_SIZE = 100 * 1024 * 1024; // 100MB
 
+// Number of leading bytes needed to identify the supported formats.
+const SNIFF_BYTES = 16;
+
+/**
+ * Detect the content type from the file's leading bytes (magic numbers).
+ * Returns the detected MIME type, or null if it does not match any supported
+ * binary format. This prevents trusting the client-supplied Content-Type,
+ * which is fully attacker-controlled.
+ */
+function sniffContentType(bytes: Uint8Array): string | null {
+  const startsWith = (sig: number[], offset = 0): boolean =>
+    sig.every((b, i) => bytes[offset + i] === b);
+
+  // ASCII helper for container/box matching.
+  const asciiAt = (offset: number, str: string): boolean =>
+    [...str].every((ch, i) => bytes[offset + i] === ch.charCodeAt(0));
+
+  // Images
+  if (startsWith([0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (startsWith([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  if (startsWith([0x47, 0x49, 0x46, 0x38])) return "image/gif"; // GIF8
+  // RIFF....WEBP
+  if (startsWith([0x52, 0x49, 0x46, 0x46]) && asciiAt(8, "WEBP")) return "image/webp";
+
+  // ISO Base Media File Format (....ftyp<brand>) — covers MP4, M4A, AVIF, etc.
+  if (asciiAt(4, "ftyp")) {
+    if (asciiAt(8, "avif") || asciiAt(8, "avis")) return "image/avif";
+    if (asciiAt(8, "M4A")) return "audio/mp4";
+    // Common MP4 brands (isom, mp42, mp41, dash, iso2, etc.) -> treat as video.
+    return "video/mp4";
+  }
+
+  // Audio
+  if (startsWith([0x49, 0x44, 0x33])) return "audio/mpeg"; // ID3 (MP3)
+  // AAC ADTS frame sync (must be checked before MPEG audio sync: ADTS uses
+  // 0xFFF1/0xFFF9 which overlaps the 0xFFFx MPEG sync space).
+  if (startsWith([0xff, 0xf1]) || startsWith([0xff, 0xf9])) return "audio/aac";
+  if (startsWith([0xff, 0xfb]) || startsWith([0xff, 0xf3]) || startsWith([0xff, 0xf2]))
+    return "audio/mpeg"; // MPEG audio frame sync
+  if (startsWith([0x66, 0x4c, 0x61, 0x43])) return "audio/flac"; // fLaC
+  // RIFF....WAVE
+  if (startsWith([0x52, 0x49, 0x46, 0x46]) && asciiAt(8, "WAVE")) return "audio/wav";
+  // OGG container — used by audio/ogg and video/ogg. Disambiguating requires
+  // deeper parsing; treat as audio/ogg (the more common case).
+  if (startsWith([0x4f, 0x67, 0x67, 0x53])) return "audio/ogg"; // OggS
+
+  // Video
+  // WebM / Matroska (EBML header) — also used by audio/webm.
+  if (startsWith([0x1a, 0x45, 0xdf, 0xa3])) return "video/webm";
+
+  // Documents
+  if (startsWith([0x25, 0x50, 0x44, 0x46])) return "application/pdf"; // %PDF
+
+  return null;
+}
+
 export async function handleUpload(c: Context<{ Bindings: Env }>) {
-  const formData = await c.req.formData();
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json({ error: "Invalid form data" }, 400);
+  }
   const file = formData.get("file") as File | null;
   const rawDir = (formData.get("directory") as string) || "";
   // Sanitize directory: strip leading/trailing slashes and drop any ".." segments.
@@ -41,12 +104,30 @@ export async function handleUpload(c: Context<{ Bindings: Env }>) {
     return c.json({ error: "No file provided" }, 400);
   }
 
+  // Fast reject on the client-declared type before reading the body. This is
+  // NOT trusted on its own — the actual bytes are verified below.
   if (!ALLOWED_TYPES.has(file.type)) {
     return c.json({ error: `File type not allowed: ${file.type}` }, 400);
   }
 
   if (file.size > MAX_SIZE) {
     return c.json({ error: `File too large (max ${MAX_SIZE / 1024 / 1024}MB)` }, 400);
+  }
+
+  // Read the body once so we can both verify it and store it. file.size is
+  // already bounded by the MAX_SIZE check above.
+  const buffer = await file.arrayBuffer();
+  if (buffer.byteLength > MAX_SIZE) {
+    return c.json({ error: `File too large (max ${MAX_SIZE / 1024 / 1024}MB)` }, 400);
+  }
+
+  // Verify the real content type from magic bytes instead of trusting the
+  // client-supplied Content-Type. Reject anything we can't positively
+  // identify as an allowed binary format (e.g. HTML/SVG/JS polyglots).
+  const head = new Uint8Array(buffer.slice(0, SNIFF_BYTES));
+  const detectedType = sniffContentType(head);
+  if (!detectedType || !ALLOWED_TYPES.has(detectedType)) {
+    return c.json({ error: "File content does not match an allowed type" }, 400);
   }
 
   // Sanitize filename to a safe basename: strip path separators, reject "..",
@@ -57,8 +138,9 @@ export async function handleUpload(c: Context<{ Bindings: Env }>) {
   // Build the R2 key: directory/filename (no leading slash)
   const key = directory ? `${directory}/${safeName}` : safeName;
 
-  await c.env.MEDIA_BUCKET.put(key, file.stream(), {
-    httpMetadata: { contentType: file.type },
+  // Store the server-detected content type, never the client-supplied one.
+  await c.env.MEDIA_BUCKET.put(key, buffer, {
+    httpMetadata: { contentType: detectedType },
   });
 
   const publicUrl = `${c.env.PUBLIC_MEDIA_URL}/${key}`;


### PR DESCRIPTION
## Automated audit fixes (6 findings)

Fixes for confirmed bugs found in an automated code audit. Every change was verified and independently reviewed (verdict: **pass**).

### Fixed
- **Stored XSS: SVG uploads allowed and served inline with attacker-controlled MIME type** — Removed image/svg+xml from ALLOWED_TYPES (it can carry inline <script>/event handlers and is served inline from the public R2 bucket at media.simonlowes.com). Combined with the magic-byte verification below, an SVG/HTML/JS payload now fails both the declared-type gate and the content sniff and is rejected with 400. Headers cannot be set here because media is served directly from the R2 public bucket, not through this worker; the defense is therefore enforced at upload time.
- **Draft blog posts are published and SEO-indexed via the slug route (missing draft filter in getStaticPaths)** — getStaticPaths now filters out drafts in production with `.filter((p) => import.meta.env.DEV || !p.data.draft)`, matching the listing pages (src/pages/index.astro, src/pages/blog/index.astro). Drafts are no longer reachable by URL or emitted with index/follow + JSON-LD in prod builds, but remain viewable during `astro dev` for previewing. (lint-staged/prettier reformatted the filter onto one line; behavior unchanged.)
- **Device orientation (gyro) input permanently ignored on Android / older iOS because auto-drift is never disabled** — Removed the unconditional `if (this.isMobile && !this.orientationPermissionGranted) this.useAutoDrift = true;` at the end of setupInput() that defeated tryDirectOrientation()'s 1s timeout fallback. tryDirectOrientation now solely owns the auto-drift fallback for the direct-orientation path. Also added `this.useAutoDrift = false;` in onDeviceOrientation() so that once real gyro events arrive, update() stops overwriting the tilt-derived targetX/targetY with the figure-8 drift. Added an explicit auto-drift branch for mobile devices lacking DeviceOrientationEvent.
- **Motion controls never activate after iOS permission grant + reload; granted flag is ignored by ParallaxController** — In setupInput()'s needsPermissionPrompt() branch, the controller now checks the persisted localStorage flag via a new hasStoredPermission() helper (reads 'motion-permission-granted'==='true', wrapped in try/catch). If set, it calls tryDirectOrientation() to re-attach the deviceorientation listener directly (the iOS session permission persists across the reload, so re-attaching works without re-prompting; calling requestPermission() again outside a user gesture would reject). If events do arrive, onDeviceOrientation() clears auto-drift; if none arrive in 1s, it falls back cleanly to auto-drift.
- **MIME type validation trusts client-supplied Content-Type (file.type)** — Added a magic-byte sniffer (sniffContentType) that reads the file's leading 16 bytes and positively identifies the format (JPEG/PNG/GIF/WEBP/AVIF, ISO-BMFF mp4/m4a, MP3/AAC-ADTS/FLAC/WAV/OGG, WebM, PDF). The handler now reads the body once into an ArrayBuffer, verifies detectedType is in ALLOWED_TYPES (rejecting anything unidentifiable like HTML/SVG/JS polyglots with 400), stores the server-detected contentType instead of file.type, and re-checks byteLength against MAX_SIZE. The client-declared type is kept only as a cheap fast-reject gate before reading the body.
- **Unhandled formData parse rejection yields opaque 500 instead of a 400** — Wrapped `await c.req.formData()` in try/catch; on rejection (missing/wrong Content-Type, malformed boundary, non-form body) it now returns c.json({ error: 'Invalid form data' }, 400), consistent with every other error path so media-store.persist surfaces a clear message instead of a generic 500.

### Decisions / assumptions
- **Upload security: enforce at upload time, not serve time**: Media is served directly from the R2 public bucket (media.simonlowes.com via PUBLIC_MEDIA_URL), not through this worker (confirmed by wrangler.toml routes + absence of any serve handler/Content-Disposition/nosniff code in workers/). Setting response headers like Content-Disposition: attachment / X-Content-Type-Options: nosniff is therefore impossible from this worker. I implemented the self-contained defense entirely at upload time: drop SVG from the allow-list and verify real content via magic bytes, rejecting anything that isn't a recognized allowed binary format.
- **Magic-byte sniffer scope and OGG/video disambiguation**: I implemented a minimal signature detector covering exactly the ALLOWED_TYPES. OGG and WebM containers can be either audio or video; without deep parsing I map OggS -> audio/ogg and EBML -> video/webm (both are allow-listed and inert), so a video/ogg upload would be stored as audio/ogg metadata. This is an accepted minor mislabel; the security property (no executable/script content can pass) holds. AAC ADTS (0xFFF1/0xFFF9) is detected before MPEG sync so legitimately-declared audio/aac uploads are not rejected.
- **Draft visibility gated on environment**: Drafts should still be previewable during local `astro dev` but never reachable or indexed in production. I gated the getStaticPaths filter on import.meta.env.DEV (per the finding's suggested option), matching the existing listing-page behavior for the published view.

### Verification
npm ci installed root deps; npm ci in workers/media-api installed worker deps. Worker typecheck `npx tsc --noEmit -p workers/media-api/tsconfig.json` passed clean. `npx vitest run` passed 94/94 tests across 4 files. `npx eslint` on the two changed frontend files (parallax.ts and blog/[...slug].astro) passed clean. The lint-staged pre-commit hook (eslint --fix + prettier) ran and passed on commit. Full-project root `tsc` reported only pre-existing errors in src/scripts/starfield.ts (unmodified by this work); zero errors in any changed file. `astro check` was not run because it requires an interactive install of @astrojs/check (not in the lockfile); covered instead by astro sync + eslint + targeted tsc. No e2e/Playwright/dev-server run per instructions.

### Reviewer notes (non-blocking)
- upload.ts now buffers the entire file into memory via file.arrayBuffer() (previously streamed via file.stream()). This is required to both sniff and store the same bytes, but with MAX_SIZE=100MB it sits close to the Cloudflare Workers 128MB memory ceiling; a near-max upload plus the existing buffer could risk OOM. Consider lowering MAX_SIZE for the worker path or sniffing only a leading slice while streaming the rest, if large uploads are expected.
- Sniffer mislabels two declared-but-allowed cases in stored metadata only (no rejection, no security impact): a legitimately-declared video/ogg is stored as audio/ogg, and an .m4a (audio/mp4) whose ftyp brand is not exactly 'M4A' (e.g. brand 'mp42') is stored as video/mp4. Both are documented by the fixer and inert; acceptable.
- Minor: the M4A brand check matches the 3-char prefix 'M4A' rather than the canonical 'M4A ' (trailing space) box, which is fine here but slightly looser than the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
