### PR TITLE
fix(deps): override react-router and react-router-dom to 7.18.2 (alerts 165/166/167)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5952,15 +5952,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -23794,35 +23785,54 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-stately": {
@@ -26440,6 +26450,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   "overrides": {
     "diff": "^8.0.3",
     "dompurify": "^3.3.1",
-    "react-router": "^6.30.4",
+    "react-router": "^7.18.2",
+    "react-router-dom": "^7.18.2",
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "serialize-javascript": "^7.0.3",


### PR DESCRIPTION
## What

Moves the `react-router` npm override from `^6.30.4` to `^7.18.2` and adds a matching `react-router-dom: ^7.18.2` override. Lockfile regenerated with npm 10 (matching CI's Node 22 toolchain).

Closes Dependabot alerts **165, 166, 167**:

| Alert | Advisory | Package | Vulnerable range | Fix |
|---|---|---|---|---|
| 165 | GHSA-337j-9hxr-rhxg (medium) | react-router | `>= 6.4.0, < 7.18.0` | 7.18.2 |
| 167 | GHSA-wrjc-x8rr-h8h6 (medium) | react-router | `>= 6.0.0, < 7.18.0` | 7.18.2 |
| 166 | GHSA-jjmj-jmhj-qwj2 (medium) | react-router-dom | `>= 6.30.2, <= 6.30.4` | no 6.x patch exists -> 7.18.2 |

Alert 166 is why the pair has to move to the 7.x line: react-router-dom 6.x has no patched release.

## Known remaining advisory (accepted, not a regression)

`npm audit` will still report **GHSA-qwww-vcr4-c8h2** (high, "React Router: RSC Mode CSRF Bypass"), range `>= 7.12.0, < 8.3.0`. This is accepted deliberately:

- The advisory's own description states it "only affects your application if you are using the unstable RSC APIs". This repo does not use RSC — `react-router` is not imported anywhere in `src/`, `tina/`, `tests/` or `workers/`; it arrives only as a transitive dependency of the TinaCMS admin SPA, and there is no `unstable_*`, `/rsc` or `react-server` usage in the tree.
- The clean version is `react-router@8.3.0`, which declares `peerDependencies: react >=19.2.7 / react-dom >=19.2.7` and `engines: node >=22.22.0`. The tree is React 18.3.1 and `tinacms@3.11.0` hard-pins `@headlessui/react@2.1.8` (peer `react ^18`), so 8.3.0 would mean a React 19 migration. That is out of scope here.

The alert will be dismissed as "vulnerable code not in use" separately.

The remaining `body-parser` low (GHSA-v422-hmwv-36x6) is pre-existing and already auto-dismissed as alert 158.

## Verification

Run locally against this branch. `npm ci` proves package.json/package-lock.json are in sync.

```
$ npx -y npm@10 audit
# distinct advisories in the tree:
#   LOW  body-parser  GHSA-v422-hmwv-36x6   (pre-existing, alert 158, auto-dismissed)
#   HIGH react-router GHSA-qwww-vcr4-c8h2   (accepted, RSC-only, see above)
# alerts 165 / 166 / 167 no longer present
6 vulnerabilities (1 low, 5 high)
```
The 5 "high" counts are one advisory plus its four dependents (`react-router-dom`, `@tinacms/app`, `@tinacms/cli`, `tinacms`, all "Depends on vulnerable versions of react-router").

```
$ npx -y npm@10 ci        -> added 2014 packages, exit 0
$ npm run lint            -> exit 0
$ npm run lint:css        -> exit 0
$ npm run format:check    -> All matched files use Prettier code style! exit 0
$ npm test                -> Test Files 4 passed (4) / Tests 94 passed (94)
$ npx astro build         -> 4 page(s) built, exit 0
$ npm run test:e2e        -> 29 passed, 4 failed
```
The 4 e2e failures are the `tests/e2e/visual.spec.ts` screenshot comparisons, and they are **pre-existing and environment-specific**: a pristine clone of `main` (799a335, no changes) produces the identical `4 failed / 29 passed` locally. They compare against `*-chromium-darwin.png` baselines captured on a different display; CI compares against the `*-chromium-linux.png` baselines and passes.

## Resolved lock shape

```
node_modules/react-router      7.18.2   (peers: react >=18, react-dom >=18 — satisfied by 18.3.1)
node_modules/react-router-dom  7.18.2
node_modules/react-router/node_modules/cookie 1.1.1
node_modules/set-cookie-parser 2.7.2     (new transitive dep of react-router 7)
@remix-run/router                        (removed — 7.x absorbed it)
```

## Out of scope / follow-up

`npx tinacms build` is broken on `main` today, independently of this change, and the failure is masked in CI by `|| echo "::warning::..."` at `.github/workflows/test.yml:77`. The Build job of the `main` run for #305 (run 30432083690, job 90511376946, before this branch existed) shows:

```
error: Invalid define value (must be an entity name or JS literal): new Object({})
##[warning]TinaCMS build failed (branch may not be indexed yet)
```

Cause: `@tinacms/cli` emits `"process.env": new Object({...})` as an esbuild `define`, which the `"@tinacms/cli": { "vite": "^6.4.3" }` override's newer esbuild rejects. Because that is the only job that would ever bundle react-router, **CI green here does not exercise the react-router 7 upgrade in the admin SPA**. Repairing the Tina build is tracked separately; it is not attempted in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
